### PR TITLE
Refactor decider configuration and async handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # decider
-Sample code - leverages the AI agent "browser-use" to accept or reject LinkedIn invitations
+
+Sample code - leverages the AI agent "browser-use" to accept or reject LinkedIn invitations.
+
+Set the following environment variables before running:
+
+- `OPENAI_API_KEY` – API key used for OpenAI requests.
+- `BRAVE_BROWSER_PATH` – path to your Brave browser executable (defaults to macOS location if unset).


### PR DESCRIPTION
## Summary
- switch to `AsyncOpenAI`
- load API key and browser path from environment
- add docstrings and logging
- make `human_delay` asynchronous
- document new environment variables

## Testing
- `python -m py_compile decider.py`

------
https://chatgpt.com/codex/tasks/task_e_687ab571bf2883229373da791b6a116b